### PR TITLE
Add sender address to CREATE2 hash

### DIFF
--- a/contracts/StakeableVestingFactory.sol
+++ b/contracts/StakeableVestingFactory.sol
@@ -49,7 +49,8 @@ contract StakeableVestingFactory is IStakeableVestingFactory {
                     beneficiary,
                     startTimestamp,
                     endTimestamp,
-                    amount
+                    amount,
+                    msg.sender
                 )
             )
         );

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,14 @@ module.exports = {
     beneficiaryAddress,
     startTimestamp,
     endTimestamp,
-    amount
+    amount,
+    deployerAddress
   ) => {
     return ethers.utils.getCreate2Address(
       stakeableVestingFactoryAddress,
       ethers.utils.solidityKeccak256(
-        ['address', 'uint32', 'uint32', 'uint192'],
-        [beneficiaryAddress, startTimestamp, endTimestamp, amount]
+        ['address', 'uint32', 'uint32', 'uint192', 'address'],
+        [beneficiaryAddress, startTimestamp, endTimestamp, amount, deployerAddress]
       ),
       ethers.utils.keccak256(
         ethers.utils.hexConcat([

--- a/test/StakeableVestingFactory.sol.js
+++ b/test/StakeableVestingFactory.sol.js
@@ -113,7 +113,8 @@ describe('StakeableVestingFactory', function () {
                         roles.beneficiary.address,
                         vestingParameters.startTimestamp,
                         vestingParameters.endTimestamp,
-                        vestingParameters.amount
+                        vestingParameters.amount,
+                        roles.owner.address
                       );
 
                       await mockApi3Token


### PR DESCRIPTION
Closes https://github.com/api3dao/stakeable-vesting/issues/16

The report recommends using a contract-level nonce to create a unique hash for CREATE2. However, that is arguably even worse than non-deterministic deployment in that with one you only need to know the nonce of your account to know the resulting address, but with this you would have to know a nonce that other people can affect.

As a nicer solution, the address of the sender is added to the CREATE2 hash, which both prevents frontrunning (at least for the intended usage scenario, a multisig calling `deployStakeableVesting()`) and still results in a deterministic deployment address.